### PR TITLE
Prevent double menu when ignoring mod updates

### DIFF
--- a/src/main/kotlin/mynameisjeff/skyblockclientupdater/gui/ChooseUpdatedModsScreen.kt
+++ b/src/main/kotlin/mynameisjeff/skyblockclientupdater/gui/ChooseUpdatedModsScreen.kt
@@ -39,6 +39,7 @@ class ChooseUpdatedModsScreen : GuiScreen() {
                 mc.displayGuiScreen(UpdateScreen(list))
             }
             else {
+                UpdateChecker.needsUpdate.clear()
                 mc.displayGuiScreen(GuiMainMenu())
             }
         }


### PR DESCRIPTION
Forgot this test case. The others work. Just add this one line.